### PR TITLE
Distinctify principals

### DIFF
--- a/schools/api.py
+++ b/schools/api.py
@@ -583,7 +583,7 @@ class EmployershipFilter(django_filters.FilterSet):
 
 
 class PrincipalViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = Principal.objects.filter(employers__end_year__lt=datetime.now().year-YEARS_OF_PRIVACY)
+    queryset = Principal.objects.filter(employers__end_year__lt=datetime.now().year-YEARS_OF_PRIVACY).distinct()
     serializer_class = PrincipalSerializer
     filter_backends = (filters.SearchFilter, filters.DjangoFilterBackend)
     filter_class = PrincipalFilter


### PR DESCRIPTION
The privacy filter will multiply principals with multiple employers, causing havoc downstream. Apply a distinct.